### PR TITLE
Add missing iterator initializer in classapplier

### DIFF
--- a/lib/rangy-classapplier.js
+++ b/lib/rangy-classapplier.js
@@ -331,7 +331,8 @@
 
         function getRangeBoundaries(ranges) {
             var positions = [], i, range;
-            for (i = 0; range = ranges[i++]; ) {
+            for 
+                0; range = ranges[i++]; ) {
                 positions.push(
                     new DomPosition(range.startContainer, range.startOffset),
                     new DomPosition(range.endContainer, range.endOffset)
@@ -741,7 +742,7 @@
 
                 // Apply the merges
                 if (merges.length) {
-                    for (i = 0, len = merges.length; i < len; ++i) {
+                    for (var i = 0, len = merges.length; i < len; ++i) {
                         merges[i].doMerge(positionsToPreserve);
                     }
 


### PR DESCRIPTION
Add missing a `var` initializer for iterator `i` in rangy-classapplier.js to resolve javascript error.